### PR TITLE
use securerandom to generate random bytes

### DIFF
--- a/lib/cryptor/symmetric_encryption/secret_key.rb
+++ b/lib/cryptor/symmetric_encryption/secret_key.rb
@@ -1,5 +1,7 @@
+require 'uri'
 require 'base64'
 require 'digest/sha2'
+require 'securerandom'
 
 module Cryptor
   class SymmetricEncryption
@@ -21,7 +23,7 @@ module Cryptor
         else fail ArgumentError, "invalid cipher: #{cipher}"
         end
 
-        bytes  = RbNaCl::Random.random_bytes(cipher.key_bytes)
+        bytes  = SecureRandom.random_bytes(cipher.key_bytes)
         base64 = Cryptor::Encoding.encode(bytes)
 
         new "secret.key:///#{cipher.algorithm};#{base64}"


### PR DESCRIPTION
When using ActiveSupport::MessageEncryptor, its not necessary to include RbNaCl if we use SecureRandom  which is included with Ruby 1.9.3+ to generate random bytes.
